### PR TITLE
Possible fix for selecting project with enter

### DIFF
--- a/lua/telescope/_extensions/monorepo.lua
+++ b/lua/telescope/_extensions/monorepo.lua
@@ -16,7 +16,7 @@ local utils = require("monorepo.utils")
 local function select_project(prompt_bufnr)
   actions.close(prompt_bufnr)
   local selection = action_state.get_selected_entry()
-  vim.api.nvim_set_current_dir(require("monorepo").currentMonorepo .. "/" .. selection.value)
+  vim.api.nvim_set_current_dir("/" .. selection.value)
   utils.notify(messages.SWITCHED_PROJECT .. ": " .. selection.value)
 end
 


### PR DESCRIPTION
When using monorepo I was trying to select and load a project after i'd entered it using the 'enter' key but this error kept showing.

<img width="1340" alt="Screenshot 2023-12-21 at 23 25 21" src="https://github.com/imNel/monorepo.nvim/assets/63661422/57cb6112-6ba1-4085-aab1-a6bfe5f7288c">

I went to line 19 in _extensions/monorepo.lua and noticed you were concatonating the existing path onto a / then onto the selection but if the selection is already a full absolute path it wouldnt need the existing one before it?

I removed the currentMonorepo and selecting different paths with enter seems to work fine